### PR TITLE
FIX: Correct tags in initial version

### DIFF
--- a/TA-Suricata/default/tags.conf
+++ b/TA-Suricata/default/tags.conf
@@ -12,7 +12,8 @@ web = enabled
 
 [eventtype=suricata_eve_tls]
 certificate = enabled
-ssl OR tls = enabled
+tls = enabled
 
-[eventtype=suricata_json_flow]
+[eventtype=suricata_eve_flow]
 network = enabled
+communicate = enabled


### PR DESCRIPTION
- Make tag on suricata_eve_tls 'tls' instead of 'ssl OR tls', which doesn't work
- Adjust tags for 'suricata_json_flow' to apply to 'suricata_eve_flow'
